### PR TITLE
Fix for parameter "%n" on shared folders

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -83,12 +83,12 @@ class Operation implements ISpecificOperation {
                                 $nodeID = $node->getId();
                         } catch (InvalidPathException $e) {
                         } catch (NotFoundException $e) {
-						}
+			}
 					
-						$base_path = $this->config->getSystemValue('datadirectory');
+			$base_path = $this->config->getSystemValue('datadirectory');
 					
-						$path = Filesystem::getLocalFile(Filesystem::getPath($nodeID));
-						$command = str_replace('%n', escapeshellarg(str_replace($base_path . '/','',$path)), $command);
+			$path = Filesystem::getLocalFile(Filesystem::getPath($nodeID));
+			$command = str_replace('%n', escapeshellarg(str_replace($base_path . '/','',$path)), $command);
 		}
 
 		if (false && strpos($command, '%f')) {

--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -23,8 +23,8 @@
 
 namespace OCA\WorkflowScript;
 
-use OC\Files\View;
 use OC\Files\Filesystem;
+use OC\Files\View;
 use OCA\WorkflowEngine\Entity\File;
 use OCA\WorkflowScript\BackgroundJobs\Launcher;
 use OCP\BackgroundJob\IJobList;
@@ -35,10 +35,10 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserSession;
-use OCP\IConfig;
 use OCP\SystemTag\MapperEvent;
 use OCP\WorkflowEngine\IManager;
 use OCP\WorkflowEngine\IRuleMatcher;
@@ -78,17 +78,17 @@ class Operation implements ISpecificOperation {
 
 		if (strpos($command, '%n')) {
 			// Nextcloud relative-path
-                        $nodeID = -1;
-                        try {
-                                $nodeID = $node->getId();
-                        } catch (InvalidPathException $e) {
-                        } catch (NotFoundException $e) {
+			$nodeID = -1;
+			try {
+				$nodeID = $node->getId();
+			} catch (InvalidPathException $e) {
+			} catch (NotFoundException $e) {
 			}
-					
+
 			$base_path = $this->config->getSystemValue('datadirectory');
-					
+
 			$path = Filesystem::getLocalFile(Filesystem::getPath($nodeID));
-			$command = str_replace('%n', escapeshellarg(str_replace($base_path . '/','',$path)), $command);
+			$command = str_replace('%n', escapeshellarg(str_replace($base_path . '/', '', $path)), $command);
 		}
 
 		if (false && strpos($command, '%f')) {

--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -23,6 +23,7 @@
 
 namespace OCA\WorkflowScript;
 
+use OC\Config;
 use OC\Files\View;
 use OCA\WorkflowEngine\Entity\File;
 use OCA\WorkflowScript\BackgroundJobs\Launcher;
@@ -34,6 +35,7 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\Files\Filesystem;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -73,7 +75,18 @@ class Operation implements ISpecificOperation {
 
 		if (strpos($command, '%n')) {
 			// Nextcloud relative-path
-			$command = str_replace('%n', escapeshellarg($node->getPath()), $command);
+                        $nodeID = -1;
+                        try {
+                                $nodeID = $node->getId();
+                        } catch (InvalidPathException $e) {
+                        } catch (NotFoundException $e) {
+                        }
+                        $config = new Config('config/');
+                        $base_path = $config->getValue('datadirectory');
+
+                        $path = Filesystem::getLocalFile(Filesystem::getPath($nodeID));
+                        $command = str_replace('%n', escapeshellarg(str_replace($base_path . '/','',$path)), $command);
+
 		}
 
 		if (false && strpos($command, '%f')) {

--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -23,8 +23,8 @@
 
 namespace OCA\WorkflowScript;
 
-use OC\Config;
 use OC\Files\View;
+use OC\Files\Filesystem;
 use OCA\WorkflowEngine\Entity\File;
 use OCA\WorkflowScript\BackgroundJobs\Launcher;
 use OCP\BackgroundJob\IJobList;
@@ -35,10 +35,10 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
-use OCP\Files\Filesystem;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\IConfig;
 use OCP\SystemTag\MapperEvent;
 use OCP\WorkflowEngine\IManager;
 use OCP\WorkflowEngine\IRuleMatcher;
@@ -57,13 +57,16 @@ class Operation implements ISpecificOperation {
 	private $session;
 	/** @var IRootFolder */
 	private $rootFolder;
+	/** @var IConfig */
+	private $config;
 
-	public function __construct(IManager $workflowEngineManager, IJobList $jobList, IL10N $l, IUserSession $session, IRootFolder $rootFolder) {
+	public function __construct(IManager $workflowEngineManager, IJobList $jobList, IL10N $l, IUserSession $session, IRootFolder $rootFolder, IConfig $config) {
 		$this->workflowEngineManager = $workflowEngineManager;
 		$this->jobList = $jobList;
 		$this->l = $l;
 		$this->session = $session;
 		$this->rootFolder = $rootFolder;
+		$this->config = $config;
 	}
 
 	protected function buildCommand(string $template, Node $node, string $event, array $extra = []) {
@@ -80,13 +83,12 @@ class Operation implements ISpecificOperation {
                                 $nodeID = $node->getId();
                         } catch (InvalidPathException $e) {
                         } catch (NotFoundException $e) {
-                        }
-                        $config = new Config('config/');
-                        $base_path = $config->getValue('datadirectory');
-
-                        $path = Filesystem::getLocalFile(Filesystem::getPath($nodeID));
-                        $command = str_replace('%n', escapeshellarg(str_replace($base_path . '/','',$path)), $command);
-
+						}
+					
+						$base_path = $this->config->getSystemValue('datadirectory');
+					
+						$path = Filesystem::getLocalFile(Filesystem::getPath($nodeID));
+						$command = str_replace('%n', escapeshellarg(str_replace($base_path . '/','',$path)), $command);
 		}
 
 		if (false && strpos($command, '%f')) {


### PR DESCRIPTION
Fix to allow '%n' parameter to give out real relative file path in shared folder scenario. 
Addressing issues: #48 and possibly #38 

### Scenario
User **A** creates Folder _/myfolder_ at shares it with User **B**
User **B** moves Folder from root dir to _/subfolder/myfolder_
User **B** creates file _/subfolder/myfolder/file1_ in this folder which triggers a workflow script:

**Result before:**
user-id (%o): A
nextcloud-relative path (%n): _B/files/subfolder/myfolder/file1_ **<---- file does not exists on drive at this position**

**Result after:**
user-id (%o): A
nextcloud-relative path (%n): _B/files/myfolder/file1_ **<---- file exists**