### PR TITLE
Bugfix: remove if false and fix full path

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -76,7 +76,7 @@ class Operation implements ISpecificOperation {
 			$command = str_replace('%n', escapeshellarg($node->getPath()), $command);
 		}
 
-		if (false && strpos($command, '%f')) {
+		if (strpos($command, '%f')) {
 			try {
 				$view = new View($node->getParent()->getPath());
 				if ($node instanceof Folder) {

--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -78,7 +78,7 @@ class Operation implements ISpecificOperation {
 
 		if (strpos($command, '%f')) {
 			try {
-				$view = new View($node->getParent()->getPath());
+				$view = new View();
 				if ($node instanceof Folder) {
 					$fullPath = $view->getLocalFolder($node->getPath());
 				} else {
@@ -87,7 +87,6 @@ class Operation implements ISpecificOperation {
 				if ($fullPath === null) {
 					throw new \InvalidArgumentException();
 				}
-				//$fullPath = $node->getParent()->getFullPath($node->getPath());
 				$command = str_replace('%f', escapeshellarg($fullPath), $command);
 			} catch (\Exception $e) {
 				throw new \InvalidArgumentException('Could not determine full path');


### PR DESCRIPTION
Removed `if(false)` and fix wrong path when I change file in mapped (shared) folder

How to reproduce?

* Loggin using user A
* create a user called B
* create a folder called test using user B
* put a file with name example.csv to run the workflow script into folder test
* goto settings and create a script flow with this settings:
    * file name: /^example.csv$/
    * script: "ls %f"
* using user B, share the test folder to user A
* with user A, change the file inside test folder
* look the jobs in database to find the command

You will find in place of %f this text: "/var/www/html/data/B/test/B/test/example.csv" you need see "/var/www/html/data/B/test/example.csv"