### PR TITLE
Open link to placeholder documentation in new tab

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -48,7 +48,8 @@
 				}),
 				createElement('a', {
 					attrs: {
-						href: self.link
+						href: self.link,
+						target: '_blank'
 					},
 					style: {
 						color: 'var(--color-text-maxcontrast)'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3902676/130600541-aaf66cf0-d679-40e7-874a-561b99686fa9.png)

When you configure a workflow_script flow and press on placeholders the current configuration is lost (as the link is opened in the current tab) :disappointed: 