### PR TITLE
[stable24] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -530,12 +530,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "64ea99903558307fb47b79b022949aca7950f3a8"
+                "reference": "844baa555f64d09ec7c29cbc8036d0efb9884581"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/64ea99903558307fb47b79b022949aca7950f3a8",
-                "reference": "64ea99903558307fb47b79b022949aca7950f3a8",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/844baa555f64d09ec7c29cbc8036d0efb9884581",
+                "reference": "844baa555f64d09ec7c29cbc8036d0efb9884581",
                 "shasum": ""
             },
             "require": {
@@ -565,7 +565,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable24"
             },
-            "time": "2022-11-05T00:47:56+00:00"
+            "time": "2022-11-11T00:48:02+00:00"
         },
         {
             "name": "php-cs-fixer/diff",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency