### PR TITLE
vendor is now necessary to ship

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -11,4 +11,3 @@ README.md
 screenshots
 tests
 .tx
-vendor

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Workflow external scripts</name>
 	<summary>Rule based processing of files through specified external scripts</summary>
 	<description>Pass files on to external scripts depending on a defined set of rules.</description>
-	<version>1.11.0</version>
+	<version>1.11.1</version>
 	<licence>agpl</licence>
 	<author mail="blizzz@arthur-schiwon.de">Arthur Schiwon</author>
 	<namespace>WorkflowScript</namespace>


### PR DESCRIPTION
… as it contains autoloading data.

fixes #146 