### PR TITLE
fix: do not use removed View::getLocalFolder()

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -25,6 +25,7 @@ namespace OCA\WorkflowScript;
 
 use Exception;
 use InvalidArgumentException;
+use OC\Files\Storage\Local;
 use OC\Files\View;
 use OC\User\NoUserException;
 use OCA\Files_Sharing\SharedStorage;
@@ -195,9 +196,14 @@ class Operation implements ISpecificOperation {
 
 		if (strpos($command, '%f')) {
 			try {
+				$fullPath = null;
 				$view = new View();
 				if ($node instanceof Folder) {
-					$fullPath = $view->getLocalFolder($node->getPath());
+					$storage = $node->getStorage();
+					if ($storage->instanceOfStorage(Local::class)) {
+						/** @var Local $storage */
+						$fullPath = $storage->getSourcePath($node->getPath());
+					}
 				} else {
 					$fullPath = $view->getLocalFile($node->getPath());
 				}


### PR DESCRIPTION
fixes #171 

Well, in theory. In practice, there is still a check that prevents workflow_script actions running against folders:

https://github.com/nextcloud/workflow_script/blob/master/lib/Operation.php#L148

That was mentioned once in a bug report, I am sure. We might have it because flows may run against the target file and the parent. It is not good to generally take out folders here. But for a different PR.

But let's say we do not have this restriction. Then, compared to 26 where `getLocalFolder` was present, these changes actually fix an uncaught exception against non-local storages, where the method is not implemented. Now they are ignored, which at least is smooth and not interrupting the actual action.

 Also, this was problematic for shared storages (only the user folder of the owner was returned), alas here we have an issue as well with both the owner and the recipient being part of the resulting path.

Due to the previously mentioned restriction against folder, this is not a blocker per se for 27, nevertheless good to get it in in this form at least.

**Update**: I am thinking this might be simply dropped for Folders in general, as there is no support across storages and it never was working anyway due to the non-folder restriction pointed out. Now, this seems very much  the better idea anyway for the actual purpose was to offer a external files locally.