### PR TITLE
[stable26] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -987,12 +987,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "e83c3af4c37a8be5d7c6a6339f4aa2c99cc74f97"
+                "reference": "6f0ffec5ace13e71f50d0735c0258fc37f4ca562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e83c3af4c37a8be5d7c6a6339f4aa2c99cc74f97",
-                "reference": "e83c3af4c37a8be5d7c6a6339f4aa2c99cc74f97",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f0ffec5ace13e71f50d0735c0258fc37f4ca562",
+                "reference": "6f0ffec5ace13e71f50d0735c0258fc37f4ca562",
                 "shasum": ""
             },
             "require": {
@@ -1022,7 +1022,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
             },
-            "time": "2023-07-06T00:47:48+00:00"
+            "time": "2023-07-17T09:26:46+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency