### PR TITLE
fix(operation): groupfolder path is user independent

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -271,7 +271,7 @@ class Operation implements ISpecificOperation {
 
 		if (isset($storage) && $storage->instanceOfStorage(GroupFolderStorage::class)) {
 			// group folders are always located within $DATADIR/__groupfolders/
-			$absPath = $storage->getLocalFile($node->getPath());
+			$absPath = $storage->getLocalFile($node->getInternalPath());
 			$pos = strpos($absPath, '/__groupfolders/');
 			// if the string cannot be found, the fallback is absolute path
 			// it should never happen #famousLastWords


### PR DESCRIPTION
getPath returns the relativ to the user, i.e.
$userid/files/$groupFolderInternalPath which is then used to contstruct the absolute path and keeping this information. By using getInernalPath() we only receive the groupfolder relativ path and can construct the correct and expected Nextcloud relative path as advertised.

Fixes #38 